### PR TITLE
centered the splash screen

### DIFF
--- a/src/components/SplashScreen.css
+++ b/src/components/SplashScreen.css
@@ -1,11 +1,14 @@
 .splash-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   height:100vh;
+  width: 100vw;
 }
 
 .splash svg {
   display: block;
-  width: 700px;
-  margin: 0 auto;
+  width: 70vw;
 }
 
 .splash svg.filter {


### PR DESCRIPTION
@AnilRedshift @knweber  There's a lot of repetitive CSS in the splash file that I haven't gotten a chance to clean up yet, but for now the splash animation is centered horizonally, vertically, and mobile friendly.  I will get to cleaning up the CSS and transition timing by later this afternoon or this weekend.